### PR TITLE
Fixed too many concurrent clients

### DIFF
--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -14,7 +14,7 @@ pub mod models;
 pub trait IteratorProvider<K: KinesisClient>: Send + Sync + Clone + 'static {
     fn get_config(&self) -> ShardProcessorConfig<K>;
 
-    async fn get_iterator(&self, shard_id: String) -> Result<GetShardIteratorOutput, Error>;
+    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput, Error>;
 }
 
 #[async_trait]
@@ -96,7 +96,7 @@ where
 
         for shard_id in self.get_config().shard_ids {
             let tx_shard_iterator_progress = tx_shard_iterator_progress.clone();
-            let resp = self.get_iterator(shard_id.clone()).await.unwrap();
+            let resp = self.get_iterator(&shard_id).await.unwrap();
             let shard_iterator: Option<String> = resp.shard_iterator().map(|s| s.into());
             tx_shard_iterator_progress
                 .clone()

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -45,20 +45,20 @@ pub fn new(
 
 pub async fn get_latest_iterator<T, K: KinesisClient>(
     iterator_provider: T,
-    shard_id: String,
+    shard_id: &str,
 ) -> Result<GetShardIteratorOutput, Error>
 where
     T: IteratorProvider<K>,
 {
     latest(&iterator_provider.get_config().client)
-        .iterator(&iterator_provider.get_config().stream, &shard_id)
+        .iterator(&iterator_provider.get_config().stream, shard_id)
         .await
 }
 
 pub async fn get_iterator_since<T, K: KinesisClient>(
     iterator_provider: T,
     starting_sequence_number: &str,
-    shard_id: String,
+    shard_id: &str,
 ) -> Result<GetShardIteratorOutput, Error>
 where
     T: IteratorProvider<K>,
@@ -67,7 +67,7 @@ where
         &iterator_provider.get_config().client,
         starting_sequence_number,
     )
-    .iterator(&iterator_provider.get_config().stream, &shard_id)
+    .iterator(&iterator_provider.get_config().stream, shard_id)
     .await
 }
 
@@ -83,7 +83,7 @@ pub async fn handle_iterator_refresh<T, K: KinesisClient>(
             let resp = get_iterator_since(
                 iterator_provider,
                 &last_sequence_id,
-                shard_iterator_progress.shard_id.clone(),
+                &shard_iterator_progress.shard_id,
             )
             .await
             .unwrap();
@@ -93,10 +93,9 @@ pub async fn handle_iterator_refresh<T, K: KinesisClient>(
             )
         }
         None => {
-            let resp =
-                get_latest_iterator(iterator_provider, shard_iterator_progress.shard_id.clone())
-                    .await
-                    .unwrap();
+            let resp = get_latest_iterator(iterator_provider, &shard_iterator_progress.shard_id)
+                .await
+                .unwrap();
             (None, resp.shard_iterator().map(|v| v.into()))
         }
     };

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -60,7 +60,7 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
         self.config.clone()
     }
 
-    async fn get_iterator(&self, shard_id: String) -> Result<GetShardIteratorOutput, Error> {
+    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput, Error> {
         get_latest_iterator(self.clone(), shard_id).await
     }
 }
@@ -71,9 +71,9 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
         self.config.clone()
     }
 
-    async fn get_iterator(&self, shard_id: String) -> Result<GetShardIteratorOutput, Error> {
+    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput, Error> {
         at_timestamp(&self.config.client, &self.from_datetime)
-            .iterator(&self.config.stream, &shard_id)
+            .iterator(&self.config.stream, shard_id)
             .await
     }
 }

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -27,7 +27,7 @@ async fn produced_record_is_processed() {
         config: ShardProcessorConfig {
             client,
             stream: "test".to_string(),
-            shard_id: "shardId-000000000000".to_string(),
+            shard_ids: vec!["shardId-000000000000".to_string()],
             tx_records,
         },
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,11 +168,10 @@ mod cli_helpers {
         from.map(|f| chrono::Utc.datetime_from_str(f, "%+").unwrap())
     }
 
-    pub fn divide_shards(source: &[String]) -> Vec<Vec<String>> {
-        let mut dest: Vec<Vec<String>> = Vec::new();
-        let mut current_buffer: Vec<String> = Vec::new();
+    pub fn divide_shards<T: Clone>(source: &[T], group_size: u32) -> Vec<Vec<T>> {
+        let mut dest: Vec<Vec<T>> = Vec::new();
+        let mut current_buffer: Vec<T> = Vec::new();
 
-        let group_size = 2;
         let mut i = 0;
         for s in source {
             if i < group_size {
@@ -226,7 +225,7 @@ mod tests {
         ];
 
         assert_eq!(
-            divide_shards(&source),
+            divide_shards::<String>(&source, 2),
             vec![
                 vec!["a".to_string(), "b".to_string()],
                 vec!["c".to_string(), "d".to_string()],
@@ -235,10 +234,13 @@ mod tests {
         );
 
         assert_eq!(
-            divide_shards(&vec!["e".to_string()]),
+            divide_shards::<String>(&vec!["e".to_string()], 2),
             vec![vec!["e".to_string()],]
         );
 
-        assert_eq!(divide_shards(&vec![]), vec![] as Vec<Vec<String>>);
+        assert_eq!(
+            divide_shards::<String>(&vec![], 2),
+            vec![] as Vec<Vec<String>>
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,10 @@ mod cli_helpers {
     }
 
     pub fn divide_shards<T: Clone>(source: &[T], group_size: u32) -> Vec<Vec<T>> {
+        if group_size == 0 {
+            return vec![];
+        }
+
         let mut dest: Vec<Vec<T>> = Vec::new();
         let mut current_buffer: Vec<T> = Vec::new();
 
@@ -240,6 +244,33 @@ mod tests {
 
         assert_eq!(
             divide_shards::<String>(&vec![], 2),
+            vec![] as Vec<Vec<String>>
+        );
+
+        assert_eq!(
+            divide_shards::<String>(&source, 5),
+            vec![vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+                "d".to_string(),
+                "e".to_string()
+            ],]
+        );
+
+        assert_eq!(
+            divide_shards::<String>(&source, 1),
+            vec![
+                vec!["a".to_string()],
+                vec!["b".to_string()],
+                vec!["c".to_string()],
+                vec!["d".to_string()],
+                vec!["e".to_string()],
+            ]
+        );
+
+        assert_eq!(
+            divide_shards::<String>(&source, 0),
             vec![] as Vec<Vec<String>>
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,33 @@ mod cli_helpers {
     pub fn parse_date(from: Option<&str>) -> Option<DateTime<Utc>> {
         from.map(|f| chrono::Utc.datetime_from_str(f, "%+").unwrap())
     }
+
+    pub fn divide_shards(source: &[String]) -> Vec<Vec<String>> {
+        let mut dest: Vec<Vec<String>> = Vec::new();
+        let mut current_buffer: Vec<String> = Vec::new();
+
+        let group_size = 2;
+        let mut i = 0;
+        for s in source {
+            if i < group_size {
+                current_buffer.push(s.clone());
+                i += 1;
+            } else {
+                dest.push(current_buffer.clone());
+                current_buffer.clear();
+
+                current_buffer.push(s.clone());
+
+                i = 1;
+            }
+        }
+
+        if !current_buffer.is_empty() {
+            dest.push(current_buffer.clone());
+        }
+
+        dest
+    }
 }
 
 #[cfg(test)]
@@ -186,5 +213,32 @@ mod tests {
     fn parse_date_test_fail() {
         let invalid_date = "xxx";
         parse_date(Some(invalid_date));
+    }
+
+    #[test]
+    fn divide() {
+        let source = vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+            "e".to_string(),
+        ];
+
+        assert_eq!(
+            divide_shards(&source),
+            vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["c".to_string(), "d".to_string()],
+                vec!["e".to_string()],
+            ]
+        );
+
+        assert_eq!(
+            divide_shards(&vec!["e".to_string()]),
+            vec![vec!["e".to_string()],]
+        );
+
+        assert_eq!(divide_shards(&vec![]), vec![] as Vec<Vec<String>>);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), io::Error> {
         });
     }
 
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(50000);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1000);
 
     let shards = get_shards(&client, &stream_name)
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,6 @@ async fn main() -> Result<(), io::Error> {
         }
     }
 
-    // let shard_ids = vec![shard_id.clone()];
     let shard_processor = kinesis::helpers::new(
         client.clone(),
         stream_name.clone(),
@@ -149,22 +148,6 @@ async fn main() -> Result<(), io::Error> {
         .run()
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-    // for shard_id in &selected_shards {
-    //     let shard_ids = vec![shard_id.clone()];
-    //     let shard_processor = kinesis::helpers::new(
-    //         client.clone(),
-    //         stream_name.clone(),
-    //         shard_ids,
-    //         from_datetime,
-    //         tx_records.clone(),
-    //     );
-    //
-    //     shard_processor
-    //         .run()
-    //         .await
-    //         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
-    // }
 
     ConsoleSink::new(
         max_messages,

--- a/src/sink/tests.rs
+++ b/src/sink/tests.rs
@@ -24,7 +24,7 @@ fn format_nb_messages_ok() {
 
 #[test]
 fn format_outputs() {
-    let console = ConsoleSink {
+    let _console = ConsoleSink {
         config: Default::default(),
     };
 


### PR DESCRIPTION
Original implementation was creating a green thread per shard. This did not scale too well.

Change is about grouping shards (per 500) and running each group on a thread.