### PR TITLE
Fixed datetime error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1073,6 +1073,7 @@ dependencies = [
  "log",
  "log4rs",
  "nix 0.26.2",
+ "thiserror",
  "tokio",
 ]
 
@@ -1183,9 +1184,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,22 @@ authors = ["Romain Gallet <rgallet@grumlimited.co.uk>"]
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.71"
-async-trait = "0.1.68"
-aws-config = { version = "0.55.3" }
-aws-sdk-kinesis = { version = "0.28.0" }
-chrono = "0.4.25"
-clap = { version = "4.3.0", features = ["derive"] }
-colored = "2.0.0"
-config = "0.13.3"
-ctrlc-async = "3.2.2"
-env_logger = "0.10.0"
-humantime = "2.1.0"
-log = "0.4.18"
-log4rs = "1.2.0"
-nix = "0.26.2"
-tokio = { version = "1.28.2", features = ["rt-multi-thread",  "macros"] }
+anyhow = "1.0"
+async-trait = "0.1"
+aws-config = { version = "0.55" }
+aws-sdk-kinesis     = { version = "0.28" }
+chrono = "0.4"
+clap = { version = "4.3", features = ["derive"] }
+colored = "2.0"
+config = "0.13"
+ctrlc-async = "3.2"
+env_logger = "0.10"
+humantime = "2.1"
+log = "0.4"
+log4rs = "1.2"
+nix = "0.26"
+thiserror = "1.0"
+tokio = { version = "1.28", features = ["rt-multi-thread",  "macros"] }
 
 [features]
 default = ["clap/cargo", "clap/derive", "config/json"]

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -76,7 +76,7 @@ pub(crate) fn selected_shards(
     shards: Vec<String>,
     stream_name: &str,
     shard_ids: &Option<Vec<String>>,
-) -> io::Result<Vec<String>> {
+) -> Result<Vec<String>> {
     let filtered = match shard_ids {
         Some(shard_ids) => shards
             .into_iter()
@@ -89,7 +89,8 @@ pub(crate) fn selected_shards(
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("No shards found for stream {}", stream_name),
-        ))
+        )
+        .into())
     } else {
         Ok(filtered)
     }
@@ -129,7 +130,7 @@ pub(crate) fn print_runtime(opt: &Opt, selected_shards: &[String]) {
 pub fn validate_time_boundaries(
     from_datetime: &Option<DateTime<Utc>>,
     to_datetime: &Option<DateTime<Utc>>,
-) -> io::Result<()> {
+) -> Result<()> {
     from_datetime
         .zip(to_datetime.as_ref())
         .iter()
@@ -138,7 +139,8 @@ pub fn validate_time_boundaries(
                 Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "from_datetime must be before to_datetime",
-                ))
+                )
+                .into())
             } else {
                 Ok(())
             }

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -3,7 +3,6 @@ use aws_sdk_kinesis::meta::PKG_VERSION;
 use chrono::{DateTime, TimeZone, Utc};
 use clap::Parser;
 use log::info;
-use std::io;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -86,11 +85,11 @@ pub(crate) fn selected_shards(
     };
 
     if filtered.is_empty() {
-        Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("No shards found for stream {}", stream_name),
-        )
-        .into())
+        Err(anyhow!(
+            "No shards found for stream {} (filtered: {})",
+            stream_name,
+            shard_ids.is_some()
+        ))
     } else {
         Ok(filtered)
     }

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -83,9 +83,7 @@ where
                                         cloned_self
                                             .get_config()
                                             .tx_records
-                                            .send(Err(PanicError {
-                                                message: format!("{:?}", e),
-                                            }))
+                                            .send(Err(ProcessError::PanicError(format!("{:?}", e))))
                                             .await
                                             .expect("Could not send error to tx_records");
                                     }
@@ -96,9 +94,9 @@ where
                             cloned_self
                                 .get_config()
                                 .tx_records
-                                .send(Err(PanicError {
-                                    message: "ShardIterator is None".to_string(),
-                                }))
+                                .send(Err(ProcessError::PanicError(
+                                    "ShardIterator is None".to_string(),
+                                )))
                                 .await
                                 .expect("");
                         }
@@ -141,9 +139,7 @@ where
             Err(e) => {
                 self.get_config()
                     .tx_records
-                    .send(Err(PanicError {
-                        message: e.to_string(),
-                    }))
+                    .send(Err(ProcessError::PanicError(e.to_string())))
                     .await
                     .expect("Could not send error to tx_records");
             }

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -11,8 +11,8 @@ use tokio::sync::Semaphore;
 use crate::iterator::at_sequence;
 use crate::iterator::latest;
 use crate::kinesis::models::{
-    PanicError, ShardProcessor, ShardProcessorADT, ShardProcessorAtTimestamp, ShardProcessorConfig,
-    ShardProcessorLatest,
+    ProcessError, ShardProcessor, ShardProcessorADT, ShardProcessorAtTimestamp,
+    ShardProcessorConfig, ShardProcessorLatest,
 };
 use crate::kinesis::ticker::TickerUpdate;
 use crate::kinesis::{IteratorProvider, ShardIteratorProgress};
@@ -25,7 +25,7 @@ pub fn new(
     from_datetime: Option<chrono::DateTime<Utc>>,
     to_datetime: Option<chrono::DateTime<Utc>>,
     semaphore: Arc<Semaphore>,
-    tx_records: Sender<Result<ShardProcessorADT, PanicError>>,
+    tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
     tx_ticker_updates: Sender<TickerUpdate>,
 ) -> Box<dyn ShardProcessor<AwsKinesisClient> + Send + Sync> {
     debug!("Creating ShardProcessor with shard {}", shard_id);

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -33,6 +33,7 @@ pub enum ProcessError {
     #[error("The stream panicked: {0}")]
     PanicError(String),
 }
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RecordResult {
     pub shard_id: String,

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -1,6 +1,6 @@
 use crate::aws::client::KinesisClient;
 use crate::kinesis::models::{
-    PanicError, RecordResult, ShardIteratorProgress, ShardProcessor, ShardProcessorADT,
+    ProcessError, RecordResult, ShardIteratorProgress, ShardProcessor, ShardProcessorADT,
     ShardProcessorAtTimestamp, ShardProcessorConfig, ShardProcessorLatest,
 };
 use crate::kinesis::ticker::TickerUpdate;
@@ -23,7 +23,7 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn seed_shards_test() {
-    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, _) = mpsc::channel::<TickerUpdate>(10);
 
     let (tx_shard_iterator_progress, mut rx_shard_iterator_progress) =
@@ -62,7 +62,7 @@ async fn seed_shards_test() {
 #[tokio::test]
 #[should_panic]
 async fn seed_shards_test_timestamp_in_future() {
-    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, _) = mpsc::channel::<TickerUpdate>(10);
 
     let (tx_shard_iterator_progress, _) = mpsc::channel::<ShardIteratorProgress>(1);
@@ -89,7 +89,7 @@ async fn seed_shards_test_timestamp_in_future() {
 
 #[tokio::test]
 async fn produced_record_is_processed() {
-    let (tx_records, mut rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, mut rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, mut rx_ticker_updates) = mpsc::channel::<TickerUpdate>(10);
 
     let client = TestKinesisClient {
@@ -147,7 +147,7 @@ async fn produced_record_is_processed() {
 
 #[tokio::test]
 async fn beyond_to_timestamp_is_received() {
-    let (tx_records, mut rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, mut rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, mut rx_ticker_updates) = mpsc::channel::<TickerUpdate>(10);
 
     let client = TestKinesisClient {
@@ -187,7 +187,7 @@ async fn beyond_to_timestamp_is_received() {
 
 #[tokio::test]
 async fn has_records_beyond_end_ts_when_has_end_ts() {
-    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, _) = mpsc::channel::<TickerUpdate>(10);
 
     let client = TestKinesisClient {
@@ -246,7 +246,7 @@ async fn has_records_beyond_end_ts_when_has_end_ts() {
 
 #[tokio::test]
 async fn has_records_beyond_end_ts_when_no_end_ts() {
-    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(10);
+    let (tx_records, _) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(10);
     let (tx_ticker_updates, _) = mpsc::channel::<TickerUpdate>(10);
 
     let client = TestKinesisClient {

--- a/src/kinesis/ticker.rs
+++ b/src/kinesis/ticker.rs
@@ -79,7 +79,7 @@ impl Ticker {
                             info!("------------------------------")
                         }
                     }
-                    sleep(delay).await;
+                    sleep(delay).await
                 }
             }
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ async fn main() -> Result<()> {
 
     let opt = Opt::parse();
 
-    let from_datetime = parse_date(opt.from_datetime.as_deref());
-    let to_datetime = parse_date(opt.to_datetime.as_deref());
+    let from_datetime = parse_date(opt.from_datetime.as_deref())?;
+    let to_datetime = parse_date(opt.to_datetime.as_deref())?;
 
     validate_time_boundaries(&from_datetime, &to_datetime)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     let client = create_client(opt.region.clone(), opt.endpoint_url.clone()).await;
 
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1000);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(1000);
 
     let shards = get_shards(&client, &opt.stream_name).await?;
 

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,8 +1,10 @@
+use anyhow::Error;
+use anyhow::Result;
 use async_trait::async_trait;
 use chrono::TimeZone;
 use log::debug;
 use std::io;
-use std::io::{BufWriter, Error, Write};
+use std::io::{BufWriter, Write};
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::kinesis::models::{PanicError, RecordResult, ShardProcessorADT};
@@ -26,7 +28,6 @@ pub trait Configurable {
     fn shard_count(&self) -> usize;
 }
 
-#[async_trait]
 pub trait SinkOutput<W>
 where
     W: Write,
@@ -200,7 +201,7 @@ where
         }
     }
 
-    fn delimiter(&self, handle: &mut BufWriter<W>) -> Result<(), Error> {
+    fn delimiter(&self, handle: &mut BufWriter<W>) -> Result<()> {
         if self.get_config().print_delimiter {
             writeln!(
                 handle,

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::io::{BufWriter, Write};
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::kinesis::models::{PanicError, RecordResult, ShardProcessorADT};
+use crate::kinesis::models::{ProcessError, RecordResult, ShardProcessorADT};
 
 pub mod console;
 pub mod file;
@@ -59,18 +59,18 @@ where
 {
     async fn run_inner(
         &mut self,
-        tx_records: Sender<Result<ShardProcessorADT, PanicError>>,
-        rx_records: Receiver<Result<ShardProcessorADT, PanicError>>,
+        tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
+        rx_records: Receiver<Result<ShardProcessorADT, ProcessError>>,
         handle: &mut BufWriter<W>,
     ) -> io::Result<()>;
 
     async fn run(
         &mut self,
-        tx_records: Sender<Result<ShardProcessorADT, PanicError>>,
-        rx_records: Receiver<Result<ShardProcessorADT, PanicError>>,
+        tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
+        rx_records: Receiver<Result<ShardProcessorADT, ProcessError>>,
     ) -> io::Result<()>;
 
-    fn handle_termination(&self, tx_records: Sender<Result<ShardProcessorADT, PanicError>>);
+    fn handle_termination(&self, tx_records: Sender<Result<ShardProcessorADT, ProcessError>>);
 
     fn delimiter(&self, handle: &mut BufWriter<W>) -> Result<(), Error>;
 
@@ -88,7 +88,7 @@ where
         &self,
         handle: &mut BufWriter<W>,
         count: u32,
-        rx_records: &mut Receiver<Result<ShardProcessorADT, PanicError>>,
+        rx_records: &mut Receiver<Result<ShardProcessorADT, ProcessError>>,
     ) -> io::Result<()>;
 }
 
@@ -100,8 +100,8 @@ where
 {
     async fn run_inner(
         &mut self,
-        tx_records: Sender<Result<ShardProcessorADT, PanicError>>,
-        mut rx_records: Receiver<Result<ShardProcessorADT, PanicError>>,
+        tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
+        mut rx_records: Receiver<Result<ShardProcessorADT, ProcessError>>,
         handle: &mut BufWriter<W>,
     ) -> io::Result<()> {
         self.delimiter(handle).unwrap();
@@ -169,8 +169,8 @@ where
                         )?;
                     }
                 },
-                Err(e) => {
-                    panic!("Error: {}", e.message);
+                Err(ProcessError::PanicError(message)) => {
+                    panic!("Error: {}", message);
                 }
             }
         }
@@ -180,14 +180,14 @@ where
 
     async fn run(
         &mut self,
-        tx_records: Sender<Result<ShardProcessorADT, PanicError>>,
-        rx_records: Receiver<Result<ShardProcessorADT, PanicError>>,
+        tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
+        rx_records: Receiver<Result<ShardProcessorADT, ProcessError>>,
     ) -> io::Result<()> {
         let output = &mut self.output();
         self.run_inner(tx_records, rx_records, output).await
     }
 
-    fn handle_termination(&self, tx_records: Sender<Result<ShardProcessorADT, PanicError>>) {
+    fn handle_termination(&self, tx_records: Sender<Result<ShardProcessorADT, ProcessError>>) {
         // Note: the exit_after_termination check is to help
         // with tests where only one handler can be registered.
         if self.get_config().exit_after_termination {
@@ -255,7 +255,7 @@ where
         &self,
         handle: &mut BufWriter<W>,
         count: u32,
-        rx_records: &mut Receiver<Result<ShardProcessorADT, PanicError>>,
+        rx_records: &mut Receiver<Result<ShardProcessorADT, ProcessError>>,
     ) -> io::Result<()> {
         handle.flush()?;
 

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -75,10 +75,10 @@ impl SinkOutput<Stdout> for ConsoleSink {
     }
 
     fn write_delimiter(&self, delimiter: &str) -> String {
-        // grey-ish
         if self.config.no_color {
             delimiter.to_string()
         } else {
+            // grey-ish
             delimiter.truecolor(128, 128, 128).to_string()
         }
     }

--- a/src/sink/console_tests.rs
+++ b/src/sink/console_tests.rs
@@ -55,7 +55,7 @@ fn format_outputs() {
 
 #[tokio::test]
 async fn expect_zero_messages_processed() {
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(1);
 
     let tx_records_clone = tx_records.clone();
 
@@ -84,7 +84,7 @@ async fn expect_zero_messages_processed() {
 
 #[tokio::test]
 async fn sending_beyondtotimestamp_should_terminate_sink() {
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(1);
 
     let tx_records_clone = tx_records.clone();
 
@@ -113,7 +113,7 @@ async fn sending_beyondtotimestamp_should_terminate_sink() {
 
 #[tokio::test]
 async fn expect_split() {
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(1);
 
     let tx_records_clone = tx_records.clone();
 

--- a/src/sink/file_tests.rs
+++ b/src/sink/file_tests.rs
@@ -1,5 +1,5 @@
 use crate::kinesis::models::ShardProcessorADT::{Progress, Termination};
-use crate::kinesis::models::{PanicError, RecordResult, ShardProcessorADT};
+use crate::kinesis::models::{ProcessError, RecordResult, ShardProcessorADT};
 use crate::sink::file::FileSink;
 use crate::sink::Sink;
 use aws_sdk_kinesis::primitives::DateTime;
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn file_sink_ok() {
-    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, PanicError>>(1);
+    let (tx_records, rx_records) = mpsc::channel::<Result<ShardProcessorADT, ProcessError>>(1);
 
     let tx_records_clone = tx_records.clone();
 


### PR DESCRIPTION
Why
====

When unparseable and/or invalid datetimes combinations are given, error messages were bare `unwrap()` display.

What
====

Provides nicer checks and display.