### PR TITLE
Rust 1.70 + bugfixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.69.0  # MSRV
+          - 1.70.0  # MSRV
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.69.0  # MSRV
+          - 1.70.0  # MSRV
 
     steps:
       - name: Checkout

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,7 +40,7 @@ script = '''
     sed -i "s/{#RELEASE_VERSION}/${RELEASE_VERSION}/" src/cli_helpers.rs
 '''
 
-[tasks.local-install]
+[tasks.install-local]
 script_runner = "bash"
 dependencies = ["release"]
 script = '''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,6 +40,14 @@ script = '''
     sed -i "s/{#RELEASE_VERSION}/${RELEASE_VERSION}/" src/cli_helpers.rs
 '''
 
+[tasks.local-install]
+script_runner = "bash"
+dependencies = ["release"]
+script = '''
+    mkdir -p ${DESTDIR}/usr/local/bin
+    sudo cp target/release/kinesis-tailr ${DESTDIR}/usr/local/bin/
+'''
+
 [tasks.install]
 script_runner = "bash"
 dependencies = ["release"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple tool to tail a Kinesis stream built with Rust.
 ### From source
 
 ```bash
-make install-local
+cargo make install-local
 ```
 
 Installs a single binary to `/usr/local/bin/kinesis-tailr`. Alternatively, use

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -97,7 +97,7 @@ pub mod client {
         ) -> Result<GetShardIteratorOutput> {
             self.client
                 .get_shard_iterator()
-                .shard_iterator_type(ShardIteratorType::AtSequenceNumber)
+                .shard_iterator_type(ShardIteratorType::AfterSequenceNumber)
                 .starting_sequence_number(starting_sequence_number)
                 .stream_name(stream)
                 .shard_id(shard_id)

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -67,6 +67,7 @@ pub mod client {
                 .shard_iterator(shard_iterator)
                 .send()
                 .await
+                .map_err(|e| e.into_service_error())
                 .map_err(|e| e.into())
         }
 
@@ -84,6 +85,7 @@ pub mod client {
                 .shard_id(shard_id)
                 .send()
                 .await
+                .map_err(|e| e.into_service_error())
                 .map_err(|e| e.into())
         }
 
@@ -101,6 +103,7 @@ pub mod client {
                 .shard_id(shard_id)
                 .send()
                 .await
+                .map_err(|e| e.into_service_error())
                 .map_err(|e| e.into())
         }
 
@@ -116,6 +119,7 @@ pub mod client {
                 .shard_id(shard_id)
                 .send()
                 .await
+                .map_err(|e| e.into_service_error())
                 .map_err(|e| e.into())
         }
 

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -7,7 +7,7 @@ use aws_sdk_kinesis::operation::get_records::GetRecordsError;
 use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
 use chrono::prelude::*;
 use chrono::{DateTime, Utc};
-use log::{debug, error, info};
+use log::{debug, info};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::time::{sleep, Duration};
@@ -67,7 +67,8 @@ where
                                             cloned_self.clone(),
                                             tx_shard_iterator_progress.clone(),
                                         )
-                                        .await;
+                                        .await
+                                        .unwrap();
                                     }
                                     Some(ProvisionedThroughputExceededException(inner)) => {
                                         debug!("ProvisionedThroughputExceededException: {}", inner);
@@ -77,10 +78,10 @@ where
                                             cloned_self.clone(),
                                             tx_shard_iterator_progress.clone(),
                                         )
-                                        .await;
+                                        .await
+                                        .unwrap();
                                     }
                                     e => {
-                                        error!("Unknown error: {:?}", e);
                                         cloned_self
                                             .get_config()
                                             .tx_records

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -92,7 +92,10 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
 pub trait ShardProcessor<K: KinesisClient>: Send + Sync {
     async fn run(&self) -> Result<()>;
 
-    async fn seed_shards(&self, tx_shard_iterator_progress: Sender<ShardIteratorProgress>);
+    async fn seed_shards(
+        &self,
+        tx_shard_iterator_progress: Sender<ShardIteratorProgress>,
+    ) -> Result<()>;
 
     async fn publish_records_shard(
         &self,

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -47,7 +47,10 @@ async fn seed_shards_test() {
         },
     };
 
-    processor.seed_shards(tx_shard_iterator_progress).await;
+    processor
+        .seed_shards(tx_shard_iterator_progress)
+        .await
+        .unwrap();
 
     let shard_iterator_progress = rx_shard_iterator_progress.recv().await.unwrap();
 
@@ -84,7 +87,10 @@ async fn seed_shards_test_timestamp_in_future() {
         from_datetime: Utc::now().add(chrono::Duration::days(1)),
     };
 
-    processor.seed_shards(tx_shard_iterator_progress).await;
+    processor
+        .seed_shards(tx_shard_iterator_progress)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Why
===

* Rust 1.70 was release
* using `AfterSequenceNumber` to recover after the last obtained sequence number
* more `anyhow` errors return type