### PR TITLE
Randomised wait upon throuput exceeded exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "log",
  "log4rs",
  "nix 0.26.2",
+ "rand",
  "thiserror",
  "tokio",
 ]
@@ -1408,6 +1409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1430,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ humantime = "2.1"
 log = "0.4"
 log4rs = "1.2"
 nix = "0.26"
+rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["rt-multi-thread",  "macros"] }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,4 +1,5 @@
 use crate::aws::client::KinesisClient;
+use crate::kinesis::models::ShardProcessorConfig;
 use anyhow::Result;
 use async_trait::async_trait;
 use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
@@ -6,83 +7,78 @@ use chrono::Utc;
 
 #[async_trait]
 pub trait ShardIterator {
-    async fn iterator<'a>(
-        &'a self,
-        stream: &'a str,
-        shard_id: &'a str,
-    ) -> Result<GetShardIteratorOutput>;
+    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput>;
 }
 
-pub fn latest<K: KinesisClient>(client: &K) -> LatestShardIterator<'_, K> {
-    LatestShardIterator { client }
+pub fn latest<K: KinesisClient>(config: &ShardProcessorConfig<K>) -> LatestShardIterator<'_, K> {
+    LatestShardIterator { config }
 }
 
 pub fn at_sequence<'a, K: KinesisClient>(
-    client: &'a K,
+    config: &'a ShardProcessorConfig<K>,
     starting_sequence_number: &'a str,
 ) -> AtSequenceShardIterator<'a, K> {
     AtSequenceShardIterator {
-        client,
+        config,
         starting_sequence_number,
     }
 }
 
 pub fn at_timestamp<'a, K: KinesisClient>(
-    client: &'a K,
+    config: &'a ShardProcessorConfig<K>,
     timestamp: &'a chrono::DateTime<Utc>,
 ) -> AtTimestampShardIterator<'a, K> {
-    AtTimestampShardIterator { client, timestamp }
+    AtTimestampShardIterator { config, timestamp }
 }
 
 pub struct LatestShardIterator<'a, K: KinesisClient> {
-    client: &'a K,
+    config: &'a ShardProcessorConfig<K>,
 }
 
 pub struct AtSequenceShardIterator<'a, K: KinesisClient> {
-    client: &'a K,
+    config: &'a ShardProcessorConfig<K>,
     starting_sequence_number: &'a str,
 }
 
 pub struct AtTimestampShardIterator<'a, K: KinesisClient> {
-    client: &'a K,
+    config: &'a ShardProcessorConfig<K>,
     timestamp: &'a chrono::DateTime<Utc>,
 }
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for LatestShardIterator<'_, K> {
-    async fn iterator<'a>(
-        &'a self,
-        stream: &'a str,
-        shard_id: &'a str,
-    ) -> Result<GetShardIteratorOutput> {
-        self.client
-            .get_shard_iterator_latest(stream, shard_id)
+    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+        self.config
+            .client
+            .get_shard_iterator_latest(&self.config.stream, &self.config.shard_id)
             .await
     }
 }
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for AtSequenceShardIterator<'_, K> {
-    async fn iterator<'a>(
-        &'a self,
-        stream: &'a str,
-        shard_id: &'a str,
-    ) -> Result<GetShardIteratorOutput> {
-        self.client
-            .get_shard_iterator_at_sequence(stream, shard_id, self.starting_sequence_number)
+    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+        self.config
+            .client
+            .get_shard_iterator_at_sequence(
+                &self.config.stream,
+                &self.config.shard_id,
+                self.starting_sequence_number,
+            )
             .await
     }
 }
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for AtTimestampShardIterator<'_, K> {
-    async fn iterator<'a>(
-        &'a self,
-        stream: &'a str,
-        shard_id: &'a str,
-    ) -> Result<GetShardIteratorOutput> {
-        self.client
-            .get_shard_iterator_at_timestamp(stream, shard_id, self.timestamp)
+    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+        self.config
+            .client
+            .get_shard_iterator_at_timestamp(
+                &self.config.stream,
+                &self.config.shard_id,
+                self.timestamp,
+            )
             .await
     }
 }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -13,40 +13,37 @@ pub trait ShardIterator {
     ) -> Result<GetShardIteratorOutput>;
 }
 
-pub fn latest<'a, K>(client: &'a K) -> Box<dyn ShardIterator + 'a + Send + Sync>
-where
-    K: KinesisClient,
-{
-    Box::new(LatestShardIterator { client })
+pub fn latest<K: KinesisClient>(client: &K) -> LatestShardIterator<'_, K> {
+    LatestShardIterator { client }
 }
 
 pub fn at_sequence<'a, K: KinesisClient>(
     client: &'a K,
     starting_sequence_number: &'a str,
-) -> Box<dyn ShardIterator + 'a + Send + Sync> {
-    Box::new(AtSequenceShardIterator {
+) -> AtSequenceShardIterator<'a, K> {
+    AtSequenceShardIterator {
         client,
         starting_sequence_number,
-    })
+    }
 }
 
 pub fn at_timestamp<'a, K: KinesisClient>(
     client: &'a K,
     timestamp: &'a chrono::DateTime<Utc>,
-) -> Box<dyn ShardIterator + 'a + Send + Sync> {
-    Box::new(AtTimestampShardIterator { client, timestamp })
+) -> AtTimestampShardIterator<'a, K> {
+    AtTimestampShardIterator { client, timestamp }
 }
 
-struct LatestShardIterator<'a, K: KinesisClient> {
+pub struct LatestShardIterator<'a, K: KinesisClient> {
     client: &'a K,
 }
 
-struct AtSequenceShardIterator<'a, K: KinesisClient> {
+pub struct AtSequenceShardIterator<'a, K: KinesisClient> {
     client: &'a K,
     starting_sequence_number: &'a str,
 }
 
-struct AtTimestampShardIterator<'a, K: KinesisClient> {
+pub struct AtTimestampShardIterator<'a, K: KinesisClient> {
     client: &'a K,
     timestamp: &'a chrono::DateTime<Utc>,
 }

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -22,7 +22,7 @@ pub mod ticker;
 pub trait IteratorProvider<K: KinesisClient>: Send + Sync + Clone + 'static {
     fn get_config(&self) -> ShardProcessorConfig<K>;
 
-    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput>;
+    async fn get_iterator(&self) -> Result<GetShardIteratorOutput>;
 }
 
 #[async_trait]
@@ -125,7 +125,7 @@ where
 
         let tx_shard_iterator_progress = tx_shard_iterator_progress.clone();
 
-        match self.get_iterator(&self.get_config().shard_id).await {
+        match self.get_iterator().await {
             Ok(resp) => {
                 let shard_iterator: Option<String> = resp.shard_iterator().map(|s| s.into());
                 tx_shard_iterator_progress

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -1,4 +1,5 @@
 use crate::aws::client::{AwsKinesisClient, KinesisClient};
+use crate::iterator::ShardIterator;
 use anyhow::Result;
 use aws_sdk_kinesis::operation::get_shard_iterator::{
     GetShardIteratorError, GetShardIteratorOutput,

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -133,7 +133,7 @@ where
                 .await?;
         }
         Ok((_, None)) => {
-            panic!("No iterator returned")
+            Err(io::Error::new(io::ErrorKind::Other, "No iterator returned"))?;
         }
         Err(e) => match e.downcast_ref::<GetShardIteratorError>() {
             Some(e) => {
@@ -147,8 +147,7 @@ where
                 }
             }
             None => {
-                debug!("Error getting iterator: {:?}", e);
-                todo!();
+                Err(e)?;
             }
         },
     };

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -70,10 +70,8 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
         self.config.clone()
     }
 
-    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput> {
-        latest(&self.config.client)
-            .iterator(&self.config.stream, shard_id)
-            .await
+    async fn get_iterator(&self) -> Result<GetShardIteratorOutput> {
+        latest(&self.config).iterator().await
     }
 }
 
@@ -83,9 +81,9 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
         self.config.clone()
     }
 
-    async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput> {
-        at_timestamp(&self.config.client, &self.from_datetime)
-            .iterator(&self.config.stream, shard_id)
+    async fn get_iterator(&self) -> Result<GetShardIteratorOutput> {
+        at_timestamp(&self.config, &self.from_datetime)
+            .iterator()
             .await
     }
 }

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -1,6 +1,6 @@
 use crate::aws::client::KinesisClient;
-use crate::iterator::at_timestamp;
-use crate::kinesis::helpers::get_latest_iterator;
+use crate::iterator::ShardIterator;
+use crate::iterator::{at_timestamp, latest};
 use crate::kinesis::ticker::TickerUpdate;
 use crate::kinesis::IteratorProvider;
 use anyhow::Result;
@@ -71,7 +71,9 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
     }
 
     async fn get_iterator(&self, shard_id: &str) -> Result<GetShardIteratorOutput> {
-        get_latest_iterator(self.clone(), shard_id).await
+        latest(&self.config.client)
+            .iterator(&self.config.stream, shard_id)
+            .await
     }
 }
 

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -1,5 +1,6 @@
 use crate::aws::client::KinesisClient;
 use crate::kinesis::helpers;
+use crate::kinesis::helpers::wait_secs;
 use crate::kinesis::models::{
     ProcessError, RecordResult, ShardIteratorProgress, ShardProcessor, ShardProcessorADT,
     ShardProcessorAtTimestamp, ShardProcessorConfig, ShardProcessorLatest,
@@ -337,6 +338,16 @@ async fn handle_iterator_refresh_ok() {
         progress.next_shard_iterator,
         Some("shard_iterator_at_sequence".to_string())
     );
+}
+
+#[test]
+fn wait_secs_ok() {
+    for _ in 0..1000 {
+        let w = wait_secs();
+
+        assert!(w <= 12);
+        assert!(w >= 1);
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Why
===

Multiple get_records requests are likely to get maximum throughput exceeded roughly at the same time. Currently the system pauses a little while before retrying, but waits the same amount of time for all (in error) shards.

What
====

Keep on retrying after a little while, as current, but with a randomised wait time per shard.
