### PR TITLE
Reverted "RetryMode::Adaptive"

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -2,7 +2,7 @@ pub mod client {
     use anyhow::Result;
     use async_trait::async_trait;
     use aws_config::meta::region::RegionProviderChain;
-    use aws_config::retry::{RetryConfig, RetryMode};
+    use aws_config::retry::RetryConfig;
     use aws_sdk_kinesis::config::Region;
     use aws_sdk_kinesis::operation::get_records::GetRecordsOutput;
     use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
@@ -154,8 +154,7 @@ pub mod client {
             };
 
             let retry_config = RetryConfig::standard()
-                .with_max_attempts(max_attempts)
-                .with_retry_mode(RetryMode::Adaptive);
+                .with_max_attempts(max_attempts);
 
             inner.retry_config(retry_config)
         }

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -153,8 +153,7 @@ pub mod client {
                 None => inner,
             };
 
-            let retry_config = RetryConfig::standard()
-                .with_max_attempts(max_attempts);
+            let retry_config = RetryConfig::standard().with_max_attempts(max_attempts);
 
             inner.retry_config(retry_config)
         }

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use std::io;
 use std::io::{BufWriter, Stdout};
 
-pub const CONSOLE_BUF_SIZE: usize = 8 * 1024;
+pub const CONSOLE_BUF_SIZE: usize = 32 * 1024;
 
 pub struct ConsoleSink {
     pub(crate) config: SinkConfig,

--- a/src/sink/file.rs
+++ b/src/sink/file.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 use crate::sink::{Configurable, SinkConfig, SinkOutput};
 
+pub const FILE_BUF_SIZE: usize = 512 * 1024; // 512Ko
+
 pub struct FileSink {
     pub(crate) config: SinkConfig,
     pub(crate) file: PathBuf,
@@ -61,6 +63,6 @@ impl SinkOutput<File> for FileSink {
                 )
             })
             .unwrap();
-        BufWriter::new(file)
+        BufWriter::with_capacity(FILE_BUF_SIZE, file)
     }
 }


### PR DESCRIPTION
Empirical performance testing seems to show a performance decrease over low number of shards with fairly busy load (ie clients contention). 

Maybe if all clients were "adaptive" would it lead to a fairer resource sharing ? For now, disabling.