### PR TITLE
UTF-8 decoding and handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-kinesis",
+ "base64",
  "chrono",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 async-trait = "0"
 aws-config = { version = "0" }
 aws-sdk-kinesis = { version = "0" }
+base64 = "0"
 chrono = { version = "0", features = ["clock", "std"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The [release page](https://github.com/grumlimited/kinesis-tailr/releases) provid
         -o, --output-file <OUTPUT_FILE>      Output file to write to
         -c, --concurrent <CONCURRENT>        Concurrent number of shards to tail
         -v, --verbose                        Display additional information
+        -n, --no-base64                      Do not base64 encode the payload upon invalid UTF-8 payloads. Print it raw instead
         -h, --help                           Print help
         -V, --version                        Print version
 
@@ -64,6 +65,16 @@ kinesis-tailr \
     --from-datetime '2023-05-04T20:57:12+00:00' \
     --max-messages 2
 ```
+
+### UTF-8
+
+`kinesis-tailr` expects payloads to be UTF-8 encoded. If a payload is not UTF-8 encoded, it will be base64 encoded and printed as such.
+
+It might be useful to print the raw payload instead though. This can be achieved with the `--no-base64` flag.
+
+Properly UTF-8 encoded payloads will be printed as such and never base64 encoded.
+
+```bash
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ It might be useful to print the raw payload instead though. This can be achieved
 
 Properly UTF-8 encoded payloads will be printed as such and never base64 encoded.
 
-```bash
-
 ### Logging
 
 General logging level for debugging can be turned on with:

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -87,6 +87,10 @@ pub struct Opt {
     /// Display additional information
     #[structopt(short, long)]
     pub verbose: bool,
+
+    /// Do not base64 encode the payload upon invalid UTF-8 payloads. Print it raw instead.
+    #[structopt(short, long)]
+    pub no_base64: bool,
 }
 
 pub(crate) fn selected_shards(

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<()> {
                         opt.print_shard_id,
                         opt.print_timestamp,
                         opt.print_delimiter,
+                        opt.no_base64,
                         shard_count,
                         file,
                     )
@@ -82,6 +83,7 @@ async fn main() -> Result<()> {
                         opt.print_shard_id,
                         opt.print_timestamp,
                         opt.print_delimiter,
+                        opt.no_base64,
                         shard_count,
                     )
                     .run(tx_records, rx_records)

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -225,9 +225,10 @@ where
     }
 
     fn format_record(&self, record_result: &RecordResult) -> String {
-        let data = std::str::from_utf8(record_result.data.as_slice())
-            .unwrap()
-            .to_string();
+        let data = match std::str::from_utf8(record_result.data.as_slice()) {
+            Ok(payload) => payload.to_string(),
+            Err(_) => String::from_utf8_lossy(record_result.data.as_slice()).to_string(),
+        };
 
         let data = if self.get_config().print_key {
             let key = record_result.partition_key.to_string();

--- a/src/sink/console.rs
+++ b/src/sink/console.rs
@@ -20,6 +20,7 @@ impl ConsoleSink {
         print_shard_id: bool,
         print_timestamp: bool,
         print_delimiter: bool,
+        no_base64: bool,
         shard_count: usize,
     ) -> Self {
         ConsoleSink {
@@ -31,6 +32,7 @@ impl ConsoleSink {
                 print_shard_id,
                 print_timestamp,
                 print_delimiter,
+                no_base64,
                 exit_after_termination: true,
             },
             shard_count,

--- a/src/sink/console_tests.rs
+++ b/src/sink/console_tests.rs
@@ -7,17 +7,7 @@ use tokio::sync::mpsc;
 #[test]
 fn format_nb_messages_ok() {
     let console = ConsoleSink {
-        config: SinkConfig {
-            max_messages: None,
-            no_color: false,
-            print_key: false,
-            print_sequence_number: false,
-            print_shard_id: false,
-            print_timestamp: false,
-            print_delimiter: false,
-            exit_after_termination: false,
-            no_base64: false,
-        },
+        config: SinkConfig::default(),
         shard_count: 1,
     };
 
@@ -57,11 +47,6 @@ fn format_outputs() {
 
 #[test]
 fn format_outputs_base64() {
-    let _console = ConsoleSink {
-        config: Default::default(),
-        shard_count: 1,
-    };
-
     let console = ConsoleSink {
         config: SinkConfig {
             no_color: true,
@@ -81,6 +66,29 @@ fn format_outputs_base64() {
     };
 
     assert_eq!(console.format_record(&record), "SGVsbG8g8JCAV29ybGQ=");
+}
+
+#[test]
+fn format_outputs_no_base64() {
+    let console = ConsoleSink {
+        config: SinkConfig {
+            no_base64: true,
+            ..Default::default()
+        },
+        shard_count: 1,
+    };
+
+    let input = b"Hello \xF0\x90\x80World";
+
+    let record = RecordResult {
+        shard_id: "shard_id".to_string(),
+        sequence_id: "sequence_id".to_string(),
+        partition_key: "partition_key".to_string(),
+        datetime: DateTime::from_secs(1_000_000_i64),
+        data: input.to_vec(),
+    };
+
+    assert_eq!(console.format_record(&record), "Hello �World");
 }
 
 #[tokio::test]

--- a/src/sink/console_tests.rs
+++ b/src/sink/console_tests.rs
@@ -16,6 +16,7 @@ fn format_nb_messages_ok() {
             print_timestamp: false,
             print_delimiter: false,
             exit_after_termination: false,
+            no_base64: false,
         },
         shard_count: 1,
     };
@@ -52,6 +53,34 @@ fn format_outputs() {
     assert_eq!(bw_console.write_shard_id("data"), "data");
     assert_eq!(bw_console.write_key("data"), "data");
     assert_eq!(bw_console.write_delimiter("data"), "data");
+}
+
+#[test]
+fn format_outputs_base64() {
+    let _console = ConsoleSink {
+        config: Default::default(),
+        shard_count: 1,
+    };
+
+    let console = ConsoleSink {
+        config: SinkConfig {
+            no_color: true,
+            ..Default::default()
+        },
+        shard_count: 1,
+    };
+
+    let input = b"Hello \xF0\x90\x80World";
+
+    let record = RecordResult {
+        shard_id: "shard_id".to_string(),
+        sequence_id: "sequence_id".to_string(),
+        partition_key: "partition_key".to_string(),
+        datetime: DateTime::from_secs(1_000_000_i64),
+        data: input.to_vec(),
+    };
+
+    assert_eq!(console.format_record(&record), "SGVsbG8g8JCAV29ybGQ=");
 }
 
 #[tokio::test]

--- a/src/sink/file.rs
+++ b/src/sink/file.rs
@@ -23,6 +23,7 @@ impl FileSink {
         print_shard_id: bool,
         print_timestamp: bool,
         print_delimiter: bool,
+        no_base64: bool,
         shard_count: usize,
         file: P,
     ) -> Self {
@@ -35,6 +36,7 @@ impl FileSink {
                 print_shard_id,
                 print_timestamp,
                 print_delimiter,
+                no_base64,
                 exit_after_termination: true,
             },
             file: file.into(),


### PR DESCRIPTION
Why
====

`kinesis-tailr` expects payloads to be UTF-8 encoded. If a payload is not UTF-8 encoded, it will be base64 encoded and printed as such.

It might be useful to print the raw payload instead though. This can be achieved with the `--no-base64` flag.

Properly UTF-8 encoded payloads will be printed as such and never base64 encoded.