### PR TITLE
Buffer flushes periodically

### DIFF
--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,4 +1,52 @@
+pub mod stream {
+    use async_trait::async_trait;
+    use aws_config::Region;
+    use aws_sdk_kinesis::operation::get_records::GetRecordsOutput;
+    use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
+    use aws_sdk_kinesis::operation::list_shards::ListShardsOutput;
+    use aws_sdk_kinesis::primitives::DateTime;
+    use chrono::Utc;
+
+    #[async_trait]
+    pub trait StreamClient: Sync + Send {
+        async fn list_shards(
+            &self,
+            stream: &str,
+            next_token: Option<&str>,
+        ) -> anyhow::Result<ListShardsOutput>;
+
+        async fn get_records(&self, shard_iterator: &str) -> anyhow::Result<GetRecordsOutput>;
+
+        async fn get_shard_iterator_at_timestamp(
+            &self,
+            stream: &str,
+            shard_id: &str,
+            timestamp: &chrono::DateTime<Utc>,
+        ) -> anyhow::Result<GetShardIteratorOutput>;
+
+        async fn get_shard_iterator_at_sequence(
+            &self,
+            stream: &str,
+            shard_id: &str,
+            starting_sequence_number: &str,
+        ) -> anyhow::Result<GetShardIteratorOutput>;
+
+        async fn get_shard_iterator_latest(
+            &self,
+            stream: &str,
+            shard_id: &str,
+        ) -> anyhow::Result<GetShardIteratorOutput>;
+
+        fn get_region(&self) -> Option<&Region>;
+
+        fn aws_datetime(timestamp: &chrono::DateTime<Utc>) -> DateTime {
+            DateTime::from_millis(timestamp.timestamp_millis())
+        }
+    }
+}
+
 pub mod client {
+    use crate::aws::stream::StreamClient;
     use anyhow::Result;
     use async_trait::async_trait;
     use aws_config::meta::region::RegionProviderChain;
@@ -9,7 +57,6 @@ pub mod client {
     use aws_sdk_kinesis::operation::get_records::GetRecordsOutput;
     use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
     use aws_sdk_kinesis::operation::list_shards::ListShardsOutput;
-    use aws_sdk_kinesis::primitives::DateTime;
     use aws_sdk_kinesis::types::ShardIteratorType;
     use aws_sdk_kinesis::Client;
     use chrono::Utc;
@@ -20,44 +67,7 @@ pub mod client {
     }
 
     #[async_trait]
-    pub trait KinesisClient: Sync + Send {
-        async fn list_shards(
-            &self,
-            stream: &str,
-            next_token: Option<&str>,
-        ) -> Result<ListShardsOutput>;
-
-        async fn get_records(&self, shard_iterator: &str) -> Result<GetRecordsOutput>;
-
-        async fn get_shard_iterator_at_timestamp(
-            &self,
-            stream: &str,
-            shard_id: &str,
-            timestamp: &chrono::DateTime<Utc>,
-        ) -> Result<GetShardIteratorOutput>;
-
-        async fn get_shard_iterator_at_sequence(
-            &self,
-            stream: &str,
-            shard_id: &str,
-            starting_sequence_number: &str,
-        ) -> Result<GetShardIteratorOutput>;
-
-        async fn get_shard_iterator_latest(
-            &self,
-            stream: &str,
-            shard_id: &str,
-        ) -> Result<GetShardIteratorOutput>;
-
-        fn get_region(&self) -> Option<&Region>;
-
-        fn aws_datetime(timestamp: &chrono::DateTime<Utc>) -> DateTime {
-            DateTime::from_millis(timestamp.timestamp_millis())
-        }
-    }
-
-    #[async_trait]
-    impl KinesisClient for AwsKinesisClient {
+    impl StreamClient for AwsKinesisClient {
         async fn list_shards(
             &self,
             stream: &str,

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -20,7 +20,7 @@ pub mod client {
     }
 
     #[async_trait]
-    pub trait KinesisClient: Sync + Send + Clone {
+    pub trait KinesisClient: Sync + Send {
         async fn list_shards(
             &self,
             stream: &str,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 
 #[async_trait]
 pub trait ShardIterator {
-    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput>;
+    async fn iterator(&self) -> Result<GetShardIteratorOutput>;
 }
 
 pub fn latest<K: KinesisClient>(config: &ShardProcessorConfig<K>) -> LatestShardIterator<'_, K> {
@@ -47,7 +47,7 @@ pub struct AtTimestampShardIterator<'a, K: KinesisClient> {
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for LatestShardIterator<'_, K> {
-    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+    async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.config
             .client
             .get_shard_iterator_latest(&self.config.stream, &self.config.shard_id)
@@ -57,7 +57,7 @@ impl<K: KinesisClient> ShardIterator for LatestShardIterator<'_, K> {
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for AtSequenceShardIterator<'_, K> {
-    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+    async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.config
             .client
             .get_shard_iterator_at_sequence(
@@ -71,7 +71,7 @@ impl<K: KinesisClient> ShardIterator for AtSequenceShardIterator<'_, K> {
 
 #[async_trait]
 impl<K: KinesisClient> ShardIterator for AtTimestampShardIterator<'_, K> {
-    async fn iterator<'a>(&'a self) -> Result<GetShardIteratorOutput> {
+    async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.config
             .client
             .get_shard_iterator_at_timestamp(

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,4 +1,4 @@
-use crate::aws::client::KinesisClient;
+use crate::aws::stream::StreamClient;
 use crate::kinesis::models::ShardProcessorConfig;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,14 +10,14 @@ pub trait ShardIterator {
     async fn iterator(&self) -> Result<GetShardIteratorOutput>;
 }
 
-pub fn latest<'a, K: KinesisClient>(
+pub fn latest<'a, K: StreamClient>(
     client: &'a K,
     config: &'a ShardProcessorConfig,
 ) -> LatestShardIterator<'a, K> {
     LatestShardIterator { client, config }
 }
 
-pub fn at_sequence<'a, K: KinesisClient>(
+pub fn at_sequence<'a, K: StreamClient>(
     client: &'a K,
     config: &'a ShardProcessorConfig,
     starting_sequence_number: &'a str,
@@ -29,7 +29,7 @@ pub fn at_sequence<'a, K: KinesisClient>(
     }
 }
 
-pub fn at_timestamp<'a, K: KinesisClient>(
+pub fn at_timestamp<'a, K: StreamClient>(
     client: &'a K,
     config: &'a ShardProcessorConfig,
     timestamp: &'a chrono::DateTime<Utc>,
@@ -41,25 +41,25 @@ pub fn at_timestamp<'a, K: KinesisClient>(
     }
 }
 
-pub struct LatestShardIterator<'a, K: KinesisClient> {
+pub struct LatestShardIterator<'a, K: StreamClient> {
     client: &'a K,
     config: &'a ShardProcessorConfig,
 }
 
-pub struct AtSequenceShardIterator<'a, K: KinesisClient> {
+pub struct AtSequenceShardIterator<'a, K: StreamClient> {
     client: &'a K,
     config: &'a ShardProcessorConfig,
     starting_sequence_number: &'a str,
 }
 
-pub struct AtTimestampShardIterator<'a, K: KinesisClient> {
+pub struct AtTimestampShardIterator<'a, K: StreamClient> {
     client: &'a K,
     config: &'a ShardProcessorConfig,
     timestamp: &'a chrono::DateTime<Utc>,
 }
 
 #[async_trait]
-impl<K: KinesisClient> ShardIterator for LatestShardIterator<'_, K> {
+impl<K: StreamClient> ShardIterator for LatestShardIterator<'_, K> {
     async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.client
             .get_shard_iterator_latest(&self.config.stream, &self.config.shard_id)
@@ -68,7 +68,7 @@ impl<K: KinesisClient> ShardIterator for LatestShardIterator<'_, K> {
 }
 
 #[async_trait]
-impl<K: KinesisClient> ShardIterator for AtSequenceShardIterator<'_, K> {
+impl<K: StreamClient> ShardIterator for AtSequenceShardIterator<'_, K> {
     async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.client
             .get_shard_iterator_at_sequence(
@@ -81,7 +81,7 @@ impl<K: KinesisClient> ShardIterator for AtSequenceShardIterator<'_, K> {
 }
 
 #[async_trait]
-impl<K: KinesisClient> ShardIterator for AtTimestampShardIterator<'_, K> {
+impl<K: StreamClient> ShardIterator for AtTimestampShardIterator<'_, K> {
     async fn iterator(&self) -> Result<GetShardIteratorOutput> {
         self.client
             .get_shard_iterator_at_timestamp(

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -22,7 +22,9 @@ pub mod ticker;
 
 #[async_trait]
 pub trait IteratorProvider<K: KinesisClient>: Send + Sync {
-    fn get_config(&self) -> &ShardProcessorConfig<K>;
+    fn get_client(&self) -> &K;
+
+    fn get_config(&self) -> &ShardProcessorConfig;
 
     async fn get_iterator(&self) -> Result<GetShardIteratorOutput>;
 }
@@ -170,7 +172,7 @@ where
         shard_iterator: &str,
         tx_shard_iterator_progress: Sender<ShardIteratorProgress>,
     ) -> Result<()> {
-        let resp = self.get_config().client.get_records(shard_iterator).await?;
+        let resp = self.get_client().get_records(shard_iterator).await?;
         let tx_ticker_updates = &self.get_config().tx_ticker_updates;
 
         let next_shard_iterator = resp.next_shard_iterator();

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -21,7 +21,7 @@ pub mod models;
 pub mod ticker;
 
 #[async_trait]
-pub trait IteratorProvider<K: KinesisClient>: Send + Sync + Clone {
+pub trait IteratorProvider<K: KinesisClient>: Send + Sync {
     fn get_config(&self) -> &ShardProcessorConfig<K>;
 
     async fn get_iterator(&self) -> Result<GetShardIteratorOutput>;
@@ -66,7 +66,7 @@ where
                                 );
                                 helpers::handle_iterator_refresh(
                                     res_clone.clone(),
-                                    self.clone(),
+                                    self,
                                     tx_shard_iterator_progress.clone(),
                                 )
                                 .await
@@ -81,7 +81,7 @@ where
                                 sleep(Duration::from_millis(milliseconds)).await;
                                 helpers::handle_iterator_refresh(
                                     res_clone.clone(),
-                                    self.clone(),
+                                    self,
                                     tx_shard_iterator_progress.clone(),
                                 )
                                 .await

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::time::{sleep, Duration};
 use GetRecordsError::{ExpiredIteratorException, ProvisionedThroughputExceededException};
 
-use crate::aws::client::KinesisClient;
+use crate::aws::stream::StreamClient;
 use crate::kinesis::helpers::wait_milliseconds;
 use crate::kinesis::models::*;
 use crate::kinesis::ticker::{ShardCountUpdate, TickerMessage};
@@ -21,7 +21,7 @@ pub mod models;
 pub mod ticker;
 
 #[async_trait]
-pub trait IteratorProvider<K: KinesisClient>: Send + Sync {
+pub trait IteratorProvider<K: StreamClient>: Send + Sync {
     fn get_client(&self) -> &K;
 
     fn get_config(&self) -> &ShardProcessorConfig;
@@ -32,7 +32,7 @@ pub trait IteratorProvider<K: KinesisClient>: Send + Sync {
 #[async_trait]
 impl<T, K> ShardProcessor<K> for T
 where
-    K: KinesisClient,
+    K: StreamClient,
     T: IteratorProvider<K>,
 {
     async fn run(&self) -> Result<()> {

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -40,8 +40,8 @@ pub fn new(
 
     match from_datetime {
         Some(from_datetime) => Box::new(ShardProcessorAtTimestamp {
+            client,
             config: ShardProcessorConfig {
-                client,
                 stream,
                 shard_id: Arc::new(shard_id),
                 to_datetime,
@@ -52,8 +52,8 @@ pub fn new(
             from_datetime,
         }),
         None => Box::new(ShardProcessorLatest {
+            client,
             config: ShardProcessorConfig {
-                client,
                 stream,
                 shard_id: Arc::new(shard_id),
                 to_datetime,
@@ -71,7 +71,12 @@ pub async fn get_latest_iterator<T, K: KinesisClient>(
 where
     T: IteratorProvider<K>,
 {
-    latest(iterator_provider.get_config()).iterator().await
+    latest(
+        iterator_provider.get_client(),
+        iterator_provider.get_config(),
+    )
+    .iterator()
+    .await
 }
 
 pub async fn get_iterator_since<T, K: KinesisClient>(
@@ -81,9 +86,13 @@ pub async fn get_iterator_since<T, K: KinesisClient>(
 where
     T: IteratorProvider<K>,
 {
-    at_sequence(iterator_provider.get_config(), starting_sequence_number)
-        .iterator()
-        .await
+    at_sequence(
+        iterator_provider.get_client(),
+        iterator_provider.get_config(),
+        starting_sequence_number,
+    )
+    .iterator()
+    .await
 }
 
 pub async fn handle_iterator_refresh<T, K: KinesisClient>(

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -14,7 +14,8 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
-use crate::aws::client::{AwsKinesisClient, KinesisClient};
+use crate::aws::client::AwsKinesisClient;
+use crate::aws::stream::StreamClient;
 use crate::iterator::at_sequence;
 use crate::iterator::latest;
 use crate::iterator::ShardIterator;
@@ -65,7 +66,7 @@ pub fn new(
     }
 }
 
-pub async fn get_latest_iterator<T, K: KinesisClient>(
+pub async fn get_latest_iterator<T, K: StreamClient>(
     iterator_provider: &T,
 ) -> Result<GetShardIteratorOutput>
 where
@@ -79,7 +80,7 @@ where
     .await
 }
 
-pub async fn get_iterator_since<T, K: KinesisClient>(
+pub async fn get_iterator_since<T, K: StreamClient>(
     iterator_provider: &T,
     starting_sequence_number: &str,
 ) -> Result<GetShardIteratorOutput>
@@ -95,7 +96,7 @@ where
     .await
 }
 
-pub async fn handle_iterator_refresh<T, K: KinesisClient>(
+pub async fn handle_iterator_refresh<T, K: StreamClient>(
     shard_iterator_progress: ShardIteratorProgress,
     iterator_provider: &T,
     tx_shard_iterator_progress: Sender<ShardIteratorProgress>,

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -66,7 +66,7 @@ pub fn new(
 }
 
 pub async fn get_latest_iterator<T, K: KinesisClient>(
-    iterator_provider: T,
+    iterator_provider: &T,
 ) -> Result<GetShardIteratorOutput>
 where
     T: IteratorProvider<K>,
@@ -75,7 +75,7 @@ where
 }
 
 pub async fn get_iterator_since<T, K: KinesisClient>(
-    iterator_provider: T,
+    iterator_provider: &T,
     starting_sequence_number: &str,
 ) -> Result<GetShardIteratorOutput>
 where
@@ -88,7 +88,7 @@ where
 
 pub async fn handle_iterator_refresh<T, K: KinesisClient>(
     shard_iterator_progress: ShardIteratorProgress,
-    iterator_provider: T,
+    iterator_provider: &T,
     tx_shard_iterator_progress: Sender<ShardIteratorProgress>,
 ) -> Result<()>
 where
@@ -97,7 +97,7 @@ where
     let cloned_shard_iterator_progress = shard_iterator_progress.clone();
 
     let result = match shard_iterator_progress.last_sequence_id {
-        Some(last_sequence_id) => get_iterator_since(iterator_provider.clone(), &last_sequence_id)
+        Some(last_sequence_id) => get_iterator_since(iterator_provider, &last_sequence_id)
             .await
             .map(|output| {
                 (

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -45,8 +45,7 @@ pub struct RecordResult {
 }
 
 #[derive(Clone)]
-pub struct ShardProcessorConfig<K: KinesisClient> {
-    pub client: K,
+pub struct ShardProcessorConfig {
     pub stream: String,
     pub shard_id: Arc<String>,
     pub to_datetime: Option<chrono::DateTime<Utc>>,
@@ -57,34 +56,44 @@ pub struct ShardProcessorConfig<K: KinesisClient> {
 
 #[derive(Clone)]
 pub struct ShardProcessorLatest<K: KinesisClient> {
-    pub config: ShardProcessorConfig<K>,
+    pub client: K,
+    pub config: ShardProcessorConfig,
 }
 
 #[derive(Clone)]
 pub struct ShardProcessorAtTimestamp<K: KinesisClient> {
-    pub config: ShardProcessorConfig<K>,
+    pub client: K,
+    pub config: ShardProcessorConfig,
     pub from_datetime: chrono::DateTime<Utc>,
 }
 
 #[async_trait]
 impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
-    fn get_config(&self) -> &ShardProcessorConfig<K> {
+    fn get_client(&self) -> &K {
+        &self.client
+    }
+
+    fn get_config(&self) -> &ShardProcessorConfig {
         &self.config
     }
 
     async fn get_iterator(&self) -> Result<GetShardIteratorOutput> {
-        latest(&self.config).iterator().await
+        latest(&self.client, &self.config).iterator().await
     }
 }
 
 #[async_trait]
 impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
-    fn get_config(&self) -> &ShardProcessorConfig<K> {
+    fn get_client(&self) -> &K {
+        &self.client
+    }
+
+    fn get_config(&self) -> &ShardProcessorConfig {
         &self.config
     }
 
     async fn get_iterator(&self) -> Result<GetShardIteratorOutput> {
-        at_timestamp(&self.config, &self.from_datetime)
+        at_timestamp(&self.client, &self.config, &self.from_datetime)
             .iterator()
             .await
     }

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -24,6 +24,7 @@ pub struct ShardIteratorProgress {
 pub enum ShardProcessorADT {
     Termination,
     BeyondToTimestamp,
+    Flush,
     Progress(Vec<RecordResult>),
 }
 

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -1,4 +1,4 @@
-use crate::aws::client::KinesisClient;
+use crate::aws::stream::StreamClient;
 use crate::iterator::ShardIterator;
 use crate::iterator::{at_timestamp, latest};
 use crate::kinesis::ticker::TickerMessage;
@@ -55,20 +55,20 @@ pub struct ShardProcessorConfig {
 }
 
 #[derive(Clone)]
-pub struct ShardProcessorLatest<K: KinesisClient> {
+pub struct ShardProcessorLatest<K: StreamClient> {
     pub client: K,
     pub config: ShardProcessorConfig,
 }
 
 #[derive(Clone)]
-pub struct ShardProcessorAtTimestamp<K: KinesisClient> {
+pub struct ShardProcessorAtTimestamp<K: StreamClient> {
     pub client: K,
     pub config: ShardProcessorConfig,
     pub from_datetime: chrono::DateTime<Utc>,
 }
 
 #[async_trait]
-impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
+impl<K: StreamClient> IteratorProvider<K> for ShardProcessorLatest<K> {
     fn get_client(&self) -> &K {
         &self.client
     }
@@ -83,7 +83,7 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorLatest<K> {
 }
 
 #[async_trait]
-impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
+impl<K: StreamClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
     fn get_client(&self) -> &K {
         &self.client
     }
@@ -100,7 +100,7 @@ impl<K: KinesisClient> IteratorProvider<K> for ShardProcessorAtTimestamp<K> {
 }
 
 #[async_trait]
-pub trait ShardProcessor<K: KinesisClient>: Send + Sync {
+pub trait ShardProcessor<K: StreamClient>: Send + Sync {
     async fn run(&self) -> Result<()>;
 
     async fn seed_shards(

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -39,8 +39,8 @@ async fn seed_shards_test() {
     let semaphore: Arc<Semaphore> = Arc::new(Semaphore::new(10));
 
     let processor = ShardProcessorLatest {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: None,
@@ -77,8 +77,8 @@ async fn seed_shards_test_timestamp_in_future() {
     let semaphore: Arc<Semaphore> = Arc::new(Semaphore::new(10));
 
     let processor = ShardProcessorAtTimestamp {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: None,
@@ -108,8 +108,8 @@ async fn produced_record_is_processed() {
     let semaphore: Arc<Semaphore> = Arc::new(Semaphore::new(10));
 
     let processor = ShardProcessorLatest {
+        client: client.clone(),
         config: ShardProcessorConfig {
-            client: client.clone(),
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: None,
@@ -157,8 +157,8 @@ async fn beyond_to_timestamp_is_received() {
 
     let to_datetime = Utc.with_ymd_and_hms(2020, 6, 1, 12, 0, 0).unwrap();
     let processor = ShardProcessorLatest {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: Some(to_datetime),
@@ -199,8 +199,8 @@ async fn has_records_beyond_end_ts_when_has_end_ts() {
 
     let to_datetime = Utc.with_ymd_and_hms(2020, 6, 1, 12, 0, 0).unwrap();
     let processor = ShardProcessorLatest {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: Some(to_datetime),
@@ -260,8 +260,8 @@ async fn has_records_beyond_end_ts_when_no_end_ts() {
     let semaphore: Arc<Semaphore> = Arc::new(Semaphore::new(10));
 
     let processor = ShardProcessorLatest {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: None,
@@ -305,8 +305,8 @@ async fn handle_iterator_refresh_ok() {
     };
 
     let provider = ShardProcessorLatest {
+        client,
         config: ShardProcessorConfig {
-            client,
             stream: "test".to_string(),
             shard_id: Arc::new("shardId-000000000000".to_string()),
             to_datetime: None,

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -321,7 +321,7 @@ async fn handle_iterator_refresh_ok() {
 
     helpers::handle_iterator_refresh(
         shard_iterator_progress,
-        provider,
+        &provider,
         tx_shard_iterator_progress,
     )
     .await

--- a/src/kinesis/tests.rs
+++ b/src/kinesis/tests.rs
@@ -14,7 +14,7 @@ use chrono::prelude::*;
 use chrono::Utc;
 use tokio::sync::{mpsc, Semaphore};
 
-use crate::aws::client::KinesisClient;
+use crate::aws::stream::StreamClient;
 use crate::kinesis::helpers;
 use crate::kinesis::helpers::wait_milliseconds;
 use crate::kinesis::models::{
@@ -353,7 +353,7 @@ pub struct TestKinesisClient {
 }
 
 #[async_trait]
-impl KinesisClient for TestKinesisClient {
+impl StreamClient for TestKinesisClient {
     async fn list_shards(
         &self,
         _stream: &str,
@@ -432,7 +432,7 @@ impl KinesisClient for TestKinesisClient {
 pub struct TestTimestampInFutureKinesisClient {}
 
 #[async_trait]
-impl KinesisClient for TestTimestampInFutureKinesisClient {
+impl StreamClient for TestTimestampInFutureKinesisClient {
     async fn list_shards(
         &self,
         _stream: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
                 let semaphore = semaphore.clone();
 
                 let shard_processor = kinesis::helpers::new(
-                    client.clone(),
+                    client,
                     stream_name,
                     shard_id,
                     from_datetime,

--- a/src/sink/buffer_flush.rs
+++ b/src/sink/buffer_flush.rs
@@ -1,0 +1,37 @@
+use crate::kinesis::models::{ProcessError, ShardProcessorADT};
+use anyhow::Result;
+use std::time::Duration;
+use tokio::sync::mpsc::Sender;
+use tokio::time::sleep;
+
+pub struct BufferTicker {
+    tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
+}
+
+impl BufferTicker {
+    pub fn new(tx_records: Sender<Result<ShardProcessorADT, ProcessError>>) -> Self {
+        Self { tx_records }
+    }
+
+    /**
+     * THis method will loop in the background and send a flush message to the
+     * shard Sink every 5 seconds.
+     */
+    pub fn start(&self) {
+        let tx_records = self.tx_records.clone();
+
+        tokio::spawn({
+            async move {
+                let delay = Duration::from_secs(5);
+
+                loop {
+                    sleep(delay).await;
+                    tx_records
+                        .send(Ok(ShardProcessorADT::Flush))
+                        .await
+                        .expect("Count not send ");
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Why
====

This is needed because if the buffer is not full (not enough message to trigger a nature flush),
then no output is displayed until ctrl^c is pressed.