### PR TITLE
Removing handling of Ctrl+c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.77.0  # MSRV
+          - 1.78.0  # MSRV
 
     steps:
       - name: Checkout
@@ -73,7 +73,7 @@ jobs:
 
   centos:
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ ci ]
 
     steps:
       - name: System dependencies
@@ -98,7 +98,7 @@ jobs:
 
   arch:
     runs-on: ubuntu-latest
-    needs: [ci]
+    needs: [ ci ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.77.0  # MSRV
+          - 1.78.0  # MSRV
 
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,17 +639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc-async"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598e9d68e769aa1283460a3b0ec0d049ccfb6170277aea37089fa3f58fd721a1"
-dependencies = [
- "nix 0.23.2",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,12 +1010,11 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
- "ctrlc-async",
  "env_logger",
  "humantime",
  "log",
  "log4rs",
- "nix 0.28.0",
+ "nix",
  "rand",
  "thiserror",
  "tokio",
@@ -1104,15 +1092,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,19 +1109,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ base64 = "0"
 chrono = { version = "0", features = ["clock", "std"] }
 clap = { version = "4", features = ["derive"] }
 colored = "2"
-ctrlc-async = "3"
 env_logger = "0"
 humantime = "2"
 log = "0"

--- a/src/aws.rs
+++ b/src/aws.rs
@@ -1,7 +1,6 @@
 pub mod stream {
     use anyhow::Result;
     use async_trait::async_trait;
-    use aws_config::Region;
     use aws_sdk_kinesis::operation::get_records::GetRecordsOutput;
     use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
     use aws_sdk_kinesis::operation::list_shards::ListShardsOutput;
@@ -37,8 +36,6 @@ pub mod stream {
             stream: &str,
             shard_id: &str,
         ) -> Result<GetShardIteratorOutput>;
-
-        fn get_region(&self) -> Option<&Region>;
 
         fn aws_datetime(timestamp: &chrono::DateTime<Utc>) -> DateTime {
             DateTime::from_millis(timestamp.timestamp_millis())
@@ -142,10 +139,6 @@ pub mod client {
                 .await
                 .map_err(SdkError::into_service_error)
                 .map_err(Into::into)
-        }
-
-        fn get_region(&self) -> Option<&Region> {
-            self.client.config().region()
         }
     }
 

--- a/src/kinesis.rs
+++ b/src/kinesis.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use aws_sdk_kinesis::operation::get_records::GetRecordsError;
 use aws_sdk_kinesis::operation::get_shard_iterator::GetShardIteratorOutput;
 use chrono::prelude::*;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use log::{debug, warn};
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -264,27 +264,6 @@ where
         }
 
         Ok(())
-    }
-
-    fn has_records_beyond_end_ts(&self, records: &[RecordResult]) -> bool {
-        match self.get_config().to_datetime {
-            Some(end_ts) if !records.is_empty() => {
-                let epoch = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
-
-                let find_most_recent_ts = |records: &[RecordResult]| -> DateTime<Utc> {
-                    records.iter().fold(epoch, |current_ts, record| {
-                        let record_ts = Utc.timestamp_nanos(record.datetime.as_nanos() as i64);
-
-                        std::cmp::max(current_ts, record_ts)
-                    })
-                };
-
-                let most_recent_ts = find_most_recent_ts(records);
-
-                most_recent_ts >= end_ts
-            }
-            _ => true,
-        }
     }
 
     fn records_before_end_ts(&self, records: Vec<RecordResult>) -> Vec<RecordResult> {

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -115,7 +115,5 @@ pub trait ShardProcessor<K: StreamClient>: Send + Sync {
         tx_shard_iterator_progress: Sender<ShardIteratorProgress>,
     ) -> Result<()>;
 
-    fn has_records_beyond_end_ts(&self, records: &[RecordResult]) -> bool;
-
     fn records_before_end_ts(&self, records: Vec<RecordResult>) -> Vec<RecordResult>;
 }


### PR DESCRIPTION
Why
====

Specific handling of `ctrl+c` signal was counter productive on heavily loaded streams. 

I used a boolean to exit the loop faster, but it was still pausing for a few seconds. A bigger overhaul would have been to pass that boolean to all shard consumers as well (ie not just the sink).

A possible alternative could be the usage of priority queues (to handle Termination signal faster).

But all in all, it now appears a counter productive handling in the sense a typical unix command would immediately exit with code 130. There is no valid reason to make `kinesis-tailr` behave any differently.