### PR TITLE
Re-introduced semaphore to limit concurrent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Arch Linux.
         --progress                           Print progress status
         --shard-id <SHARD_ID>                Shard ID to tail from. Repeat option for each shard ID to filter on
         -o, --output-file <OUTPUT_FILE>      Output file to write to
+        -c, --concurrent <CONCURRENT>        Concurrent number of shards to tail
         -v, --verbose                        Display additional information
             --base64                         Base64 encode payloads (eg. for binary data)
             --utf8                           Forces UTF-8 printable payloads

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -5,6 +5,8 @@ use chrono::{DateTime, Utc};
 use clap::Parser;
 use log::info;
 
+pub const SEMAPHORE_DEFAULT_SIZE: usize = 50;
+
 #[derive(Debug, Parser)]
 #[command(
     version = "{#RELEASE_VERSION} - Grum Ltd\nReport bugs to https://github.com/grumlimited/kinesis-tailr/issues"
@@ -78,6 +80,10 @@ pub struct Opt {
     /// Output file to write to
     #[structopt(long, short)]
     pub output_file: Option<String>,
+
+    /// Concurrent number of shards to tail
+    #[structopt(short, long)]
+    pub concurrent: Option<usize>,
 
     /// Display additional information
     #[structopt(short, long)]

--- a/src/kinesis/helpers.rs
+++ b/src/kinesis/helpers.rs
@@ -11,6 +11,7 @@ use aws_sdk_kinesis::types::Shard;
 use chrono::Utc;
 use log::{debug, info};
 use tokio::sync::mpsc::Sender;
+use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
 use crate::aws::client::AwsKinesisClient;
@@ -32,6 +33,7 @@ pub fn new(
     shard_id: String,
     from_datetime: Option<chrono::DateTime<Utc>>,
     to_datetime: Option<chrono::DateTime<Utc>>,
+    semaphore: Arc<Semaphore>,
     tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
     tx_ticker_updates: Option<Sender<TickerMessage>>,
 ) -> Box<dyn ShardProcessor<AwsKinesisClient> + Send + Sync> {
@@ -44,6 +46,7 @@ pub fn new(
                 stream,
                 shard_id: Arc::new(shard_id),
                 to_datetime,
+                semaphore,
                 tx_records,
                 tx_ticker_updates,
             },
@@ -55,6 +58,7 @@ pub fn new(
                 stream,
                 shard_id: Arc::new(shard_id),
                 to_datetime,
+                semaphore,
                 tx_records,
                 tx_ticker_updates,
             },

--- a/src/kinesis/models.rs
+++ b/src/kinesis/models.rs
@@ -12,6 +12,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::Semaphore;
 
 #[derive(Debug, Clone)]
 pub struct ShardIteratorProgress {
@@ -49,6 +50,7 @@ pub struct ShardProcessorConfig {
     pub stream: String,
     pub shard_id: Arc<String>,
     pub to_datetime: Option<chrono::DateTime<Utc>>,
+    pub semaphore: Arc<Semaphore>,
     pub tx_records: Sender<Result<ShardProcessorADT, ProcessError>>,
     pub tx_ticker_updates: Option<Sender<TickerMessage>>,
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -224,7 +224,6 @@ where
                             total_records_processed += records.len() as u32;
                             records.iter().for_each(|record| {
                                 let data = self.format_record(record);
-                                // writeln!(handle, "{}", data).unwrap();
                                 let _ = handle.write(data.as_slice()).unwrap();
                                 self.delimiter(handle).unwrap()
                             });


### PR DESCRIPTION
Why
===

On very large streams (1024+ shards), the underlying connections (1024 in this case) saturate the network stack and crash.